### PR TITLE
refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@
 
 [![NPM](https://nodei.co/npm/empty-dir.png)](https://nodei.co/npm/empty-dir/)
 
-Note that directories with `.DS_Store` on mac are considered empty.
+## Install
 
-## Example
+Install with [npm](https://www.npmjs.com/):
+
+```sh
+$ npm install --save empty-dir
+```
+
+## Usage
+
 ```js
-const emptyDir = require('empty-dir');
+var emptyDir = require('empty-dir');
 
 emptyDir('./', function (err, result) {
   if (err) {
@@ -21,32 +28,32 @@ var result = emptyDir.sync('./test/empty');
 console.log('Directory is empty:', result);
 ```
 
-**Filter function**
+## Filter function
 
-Both async and sync take a filter function as the second argument.
+Both async and sync take a filter function as the second argument, to ignore files like `.DS_Store` on mac or `Thumbs.db` on windows from causing false-negatives.
 
-_(This gives you the ability to eliminate files like `.DS_Store` on mac, or `Thumbs.db` on windows from causing the result to be "not empty" (`.DS_Store` is already filtered by default).)_
 
 ```js
-const emptyDir = require('empty-dir');
+var emptyDir = require('empty-dir');
 
 function filter(filepath) {
-  return !/Thumbs\.db$/i.test(filepath);
+  return !/(Thumbs\.db|\.DS_Store)$/i.test(filepath);
 }
 
-emptyDir('./', filter, function (err, result) {
+emptyDir('./', filter, function (err, isEmpty) {
   if (err) {
     console.error(err);
   } else {
-    console.log('Directory is empty:', result);
+    console.log('Directory is empty:', isEmpty);
   }
 });
 
-var result = emptyDir.sync('./test/empty', filter);
-console.log('Directory is empty:', result);
+var isEmpty = emptyDir.sync('./test/empty', filter);
+console.log('Directory is empty:', isEmpty);
 ```
 
 ## Release History
 
-* 2014-05-08 - v0.1.0 - initial release
+* 2018-03-09 - v1.0.0 - refactored "isEmpty" logic so that it returns early, as soon as a non-filtered file is encountered, instead of filtering the entire list and comparing against length. Also allows an array to be passed (this avoids having to call `fs.readdir()` multiple times).
 * 2016-02-07 - v0.2.0 - add filter support
+* 2014-05-08 - v0.1.0 - initial release

--- a/index.js
+++ b/index.js
@@ -22,13 +22,15 @@ function emptyDir(dir, filter, cb) {
     return;
   }
 
-  if (!isDirectory(dir)) {
-    cb(null, false);
-    return;
-  }
+  fs.stat(dir, function(err, stat) {
+    if (err || !stat.isDirectory()) {
+      cb(null, false);
+      return;
+    }
 
-  fs.readdir(dir, function(err, files) {
-    cb(err, isEmpty(files, filter));
+    fs.readdir(dir, function(err, files) {
+      cb(err, isEmpty(files, filter));
+    });
   });
 }
 
@@ -77,12 +79,12 @@ function isEmpty(files, filter) {
 }
 
 /**
- * Returns true if "dir" exists and is a directory
+ * Returns true if the filepath exists and is a directory
  */
 
-function isDirectory(dir) {
+function isDirectory(filepath) {
   try {
-    return fs.statSync(dir).isDirectory();
+    return fs.statSync(filepath).isDirectory();
   } catch (err) {}
   return false;
 }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function emptyDir(dir, filter, cb) {
     return;
   }
 
-  if (!fs.existsSync(dir)) {
+  if (!isDirectory(dir)) {
     cb(null, false);
     return;
   }
@@ -46,7 +46,7 @@ function emptyDirSync(dir, filter) {
     throw new TypeError('expected a directory or array of files');
   }
 
-  if (!fs.existsSync(dir)) {
+  if (!isDirectory(dir)) {
     return false;
   }
 
@@ -67,12 +67,24 @@ function isEmpty(files, filter) {
   if (typeof filter !== 'function') {
     return false;
   }
+
   for (var i = 0; i < files.length; ++i) {
     if (filter(files[i]) === false) {
       return false;
     }
   }
   return true;
+}
+
+/**
+ * Returns true if "dir" exists and is a directory
+ */
+
+function isDirectory(dir) {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch (err) {}
+  return false;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -19,16 +19,13 @@
   "scripts": {
     "test": "mocha"
   },
-  "dependencies": {
-    "fs-exists-sync": "^0.1.0"
-  },
-  "devDependencies": {
-    "chai": "~1.9.1",
-    "mocha": "~1.18.2"
-  },
   "keywords": [
-    "empty directory",
-    "empty dir",
-    "empty folder"
-  ]
+    "empty",
+    "is-empty",
+    "directory",
+    "folder"
+  ],
+  "devDependencies": {
+    "mocha": "^3.5.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "empty-dir",
   "description": "Check if a directory is empty.",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "homepage": "https://github.com/js-cli/js-empty-dir",
   "author": "Tyler Kellen <http://goingslowly.com/>",
   "repository": "js-cli/js-empty-dir",

--- a/test/index.js
+++ b/test/index.js
@@ -1,32 +1,73 @@
-const emptyDir = require('../');
-const expect = require('chai').expect;
-const fs = require('fs');
+var emptyDir = require('../');
+var assert = require('assert');
+var fs = require('fs');
 
 try {
   fs.mkdirSync('./test/empty');
 } catch (e) {}
 
+function isGarbageFile(filename) {
+  return /(?:Thumbs\.db|\.DS_Store)$/i.test(filename);
+}
+
 describe('emptyDir', function () {
+  it('should throw when a callback is not passed', function () {
+    assert.throws(function() {
+      emptyDir('./');
+    });
+  });
+
+  it('should throw when invalid arguments are passed', function (done) {
+    assert.throws(function() {
+      emptyDir.sync(null);
+    });
+
+    emptyDir(null, function(err) {
+      assert(err);
+      assert(/expected/.test(err.message));
+      done();
+    });
+  });
+
+  it('should take an array', function (done) {
+    assert(!emptyDir.sync(['Thumbs.db', '.DS_Store']));
+    emptyDir(['Thumbs.db', '.DS_Store'], function(err, empty) {
+      assert(!empty);
+      done();
+    });
+  });
+
+  it('should take a filter function to exclude files', function (done) {
+    assert(emptyDir.sync(['Thumbs.db', '.DS_Store'], isGarbageFile));
+    assert(!emptyDir.sync(['Thumbs.db', '.DS_Store', 'foo'], isGarbageFile));
+
+    emptyDir(['Thumbs.db', '.DS_Store'], isGarbageFile, function(err, empty) {
+      assert(empty);
+      done();
+    });
+  });
+
   it('should call back with true if a directory is empty', function (done) {
-    expect(emptyDir.sync('./')).to.be.false;
-    emptyDir('./', function (err, empty) {
-      expect(empty).to.be.false;
+    assert(!emptyDir.sync('./'));
+    emptyDir('./', function(err, empty) {
+      assert(!empty);
       done();
     });
   });
 
   it('should be false if a directory does not exist', function (done) {
-    expect(emptyDir.sync('./foo/bar/baz')).to.be.false;
+    assert(!emptyDir.sync('./foo/bar/baz'));
     emptyDir('./foo/bar/baz', function (err, empty) {
-      expect(empty).to.be.false;
+      assert(!empty);
       done();
     });
   });
 
   it('should call back with false if a directory is not empty', function (done) {
-    expect(emptyDir.sync('./test/empty')).to.be.true;
+    assert(!emptyDir.sync('./test'));
+    assert(emptyDir.sync('./test/empty'));
     emptyDir('./test/empty', function (err, empty) {
-      expect(empty).to.be.true;
+      assert(empty);
       done();
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,10 @@
 var emptyDir = require('../');
 var assert = require('assert');
+var path = require('path');
 var fs = require('fs');
 
 try {
-  fs.mkdirSync('./test/empty');
+  fs.mkdirSync(path.join(__dirname, 'empty'));
 } catch (e) {}
 
 function isGarbageFile(filename) {
@@ -13,8 +14,8 @@ function isGarbageFile(filename) {
 describe('emptyDir', function () {
   it('should throw when a callback is not passed', function () {
     assert.throws(function() {
-      emptyDir('./');
-    });
+      emptyDir('./')
+    }, /expected/);
   });
 
   it('should throw when invalid arguments are passed', function (done) {


### PR DESCRIPTION
- now allows an array to be passed (this avoids having to call `fs.readdir()` multiple times)
- use `fs.existsSync` since the sync version of `exists` is not deprecated apparently
- refactor "isEmpty" logic so that it returns early, as soon as a non-filtered file is encountered, instead of filtering the entire list and comparing against length

@tkellen, @phated please review. If you're good with the changes I'll update the readme and publish