### PR TITLE
update mocha & chai

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "fs-exists-sync": "^0.1.0"
   },
   "devDependencies": {
-    "chai": "~1.9.1",
-    "mocha": "~1.18.2"
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0"
   },
   "keywords": [
     "empty directory",


### PR DESCRIPTION
prevents:
(node:63942) DeprecationWarning: child_process: options.customFds
option is deprecated. Use options.stdio instead.