### PR TITLE
Fix incorrect documented usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Both async and sync take a filter function as the second argument, to ignore fil
 var emptyDir = require('empty-dir');
 
 function filter(filepath) {
-  return !/(Thumbs\.db|\.DS_Store)$/i.test(filepath);
+  return /(Thumbs\.db|\.DS_Store)$/i.test(filepath);
 }
 
 emptyDir('./', filter, function(err, isEmpty) {


### PR DESCRIPTION
The documented example usage of this package is backwards. Using the example code as it is currently, here's what happens:

```sh
mkdir i-should-be-empty
touch i-should-be-empty/Thumbs.db
touch i-should-be-empty/.DS_Store
```

```js
const emptyDir = require('empty-dir');

function filter(filepath) {
  return !/(Thumbs\.db|\.DS_Store)$/i.test(filepath);
}

console.log(emptyDir.sync('./i-should-be-empty', filter));
```

This prints:

```
false
```

when clearly this directory should be considered "empty" due to containing nothing but unwanted garbage files.

Compare with the filter used during unit testing, which is correct:

https://github.com/gulpjs/empty-dir/blob/4817e656907fe58fcb3e4b41fde7363812a8f737/test/index.js#L13-L15