### PR TITLE
chore: Normalize repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ MIT
 [npm-image]: https://img.shields.io/npm/v/empty-dir.svg?style=flat-square
 
 [ci-url]: https://github.com/gulpjs/empty-dir/actions?query=workflow:dev
-[ci-image]: https://img.shields.io/github/workflow/status/gulpjs/empty-dir/dev?style=flat-square
+[ci-image]: https://img.shields.io/github/actions/workflow/status/gulpjs/empty-dir/dev.yml?branch=master&style=flat-square
 
 [coveralls-url]: https://coveralls.io/r/gulpjs/empty-dir
 [coveralls-image]: https://img.shields.io/coveralls/gulpjs/empty-dir/master.svg?style=flat-square


### PR DESCRIPTION
The URL of GitHub workflow badge was changed by badges/shields's issue `#8671`.
This PR modifies the URL in `README.md`.